### PR TITLE
Remove duplicated $response property.

### DIFF
--- a/src/Entity/JsonResponseTrait.php
+++ b/src/Entity/JsonResponseTrait.php
@@ -12,11 +12,6 @@ use Psr\Http\Message\ResponseInterface;
 
 trait JsonResponseTrait
 {
-    /**
-     * @var \Psr\Http\Message\ResponseInterface
-     */
-    protected $response;
-
     protected $responseJson;
 
     public function getResponseData()


### PR DESCRIPTION
This would solve duplicated property defined by trait as reported under #2 

Signed-off-by: crynobone <crynobone@gmail.com>