### PR TITLE
Add get method for message timestamp

### DIFF
--- a/src/Message/InboundMessage.php
+++ b/src/Message/InboundMessage.php
@@ -138,6 +138,11 @@ class InboundMessage implements MessageInterface, \ArrayAccess
         return $this['network'];
     }
 
+    public function getMessageTimestamp()
+    {
+        return $this['message-timestamp'];
+    }
+
     /**
      * Allow the object to access the data from the API response, a sent API request, or the user set data that the
      * request will be created from - in that order.

--- a/test/Message/InboundMessageTest.php
+++ b/test/Message/InboundMessageTest.php
@@ -56,6 +56,7 @@ class InboundMessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('02000000DA7C52E7', $message->getMessageId());
         $this->assertEquals('Test this.', $message->getBody());
         $this->assertEquals('text', $message->getType());
+        $this->assertEquals('2016-05-24 11:12:01', $message->getMessageTimestamp());
     }
 
 
@@ -72,6 +73,7 @@ class InboundMessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('02000000DA7C52E7', $message['messageId']);
         $this->assertEquals('Test this.', $message['text']);
         $this->assertEquals('text', $message['type']);
+        $this->assertEquals('2016-05-24 11:12:01', $message['message-timestamp']);
     }
 
     /**
@@ -89,6 +91,7 @@ class InboundMessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Test this.', $message->getBody());
         $this->assertEquals('6cff3913', $message->getAccountId());
         $this->assertEquals('US-VIRTUAL-BANDWIDTH', $message->getNetwork());
+        $this->assertEquals('2016-05-24 11:12:01', $message->getMessageTimestamp());
     }
 
     /**
@@ -107,6 +110,7 @@ class InboundMessageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('MO', $message['type']);
         $this->assertEquals('6cff3913', $message['account-id']);
         $this->assertEquals('US-VIRTUAL-BANDWIDTH', $message['network']);
+        $this->assertEquals('2016-05-24 11:12:01', $message['message-timestamp']);
     }
 
     public function testCanCreateReply()

--- a/test/Message/responses/search-inbound.json
+++ b/test/Message/responses/search-inbound.json
@@ -5,6 +5,6 @@
   "from": "14845552121",
   "to": "16105553939",
   "body": "Test this.",
-  "date-received": "2016-05-24 11:12:01",
+  "message-timestamp": "2016-05-24 11:12:01",
   "type": "MO"
 }


### PR DESCRIPTION
According to the docs [incoming message](https://docs.nexmo.com/messaging/sms-api/api-reference#inbound) the message timestamp is a required key in a request. Therefore i've added a corresponding method.

Furthermore I've (probably) identified a crucial bug (typo).
You've always used the key `date-received` instead of `message-timestamp`.
`date-received` is never mentioned in the official docs.

Cheers
