### PR TITLE
Fixing abstract class method signatures in message objects

### DIFF
--- a/src/Message/Binary.php
+++ b/src/Message/Binary.php
@@ -45,9 +45,9 @@ class Binary extends Message
     /**
      * Get an array of params to use in an API request.
      */
-    public function getRequestData()
+    public function getRequestData($sent = true)
     {
-        return array_merge(parent::getRequestData(), array(
+        return array_merge(parent::getRequestData($sent), array(
             'body' => $this->body,
             'udh'  => $this->udh,
         ));

--- a/src/Message/Unicode.php
+++ b/src/Message/Unicode.php
@@ -37,9 +37,9 @@ class Unicode extends Message
     /**
      * Get an array of params to use in an API request.
      */
-    public function getRequestData()
+    public function getRequestData($sent = true)
     {
-        return array_merge(parent::getRequestData(), array(
+        return array_merge(parent::getRequestData($sent), array(
             'text' => $this->text
         ));        
     }

--- a/src/Message/Vcal.php
+++ b/src/Message/Vcal.php
@@ -37,9 +37,9 @@ class Vcal extends Message
     /**
      * Get an array of params to use in an API request.
      */
-    public function getRequestData()
+    public function getRequestData($sent = true)
     {
-        return array_merge(parent::getRequestData(), array(
+        return array_merge(parent::getRequestData($sent), array(
             'vcal' => $this->vcal
         ));        
     }

--- a/src/Message/Vcard.php
+++ b/src/Message/Vcard.php
@@ -37,9 +37,9 @@ class Vcard extends Message
     /**
      * Get an array of params to use in an API request.
      */
-    public function getRequestData()
+    public function getRequestData($sent = true)
     {
-        return array_merge(parent::getRequestData(), array(
+        return array_merge(parent::getRequestData($sent), array(
             'vcard' => $this->vcard
         ));
     }

--- a/src/Message/Wap.php
+++ b/src/Message/Wap.php
@@ -53,9 +53,9 @@ class Wap extends Message
     /**
      * Get an array of params to use in an API request.
      */
-    public function getRequestData()
+    public function getRequestData($sent = true)
     {
-        return array_merge(parent::getRequestData(), array(
+        return array_merge(parent::getRequestData($sent), array(
             'title'      => $this->title,
             'url'        => $this->url,
             'validity'   => $this->validity,


### PR DESCRIPTION
This is broken in the current `@beta` composer release. All of these classes will break (read: FATAL error) when being used because they don't implement the abstract method signature properly.

Method signature declaration here:
https://github.com/Nexmo/nexmo-php/blob/master/src/Entity/EntityInterface.php#L16