### PR TITLE
Detect HTTP 429 when searching messages

### DIFF
--- a/src/Message/Client.php
+++ b/src/Message/Client.php
@@ -171,19 +171,20 @@ class Client implements ClientAwareInterface
         $response = $this->client->send($request);
 
         $response->getBody()->rewind();
-        
-        $data = json_decode($response->getBody()->getContents(), true);
 
-        if(!$data){
-            throw new Exception\Request('no message found for `' . $id . '`');
-        }
+        $data = json_decode($response->getBody()->getContents(), true);
 
         if($response->getStatusCode() != '200' && isset($data['error-code'])){
             throw new Exception\Request($data['error-code-label'], $data['error-code']);
+        } elseif($response->getStatusCode() == '429'){
+            throw new Exception\Request('too many concurrent requests', $response->getStatusCode());
         } elseif($response->getStatusCode() != '200'){
             throw new Exception\Request('error status from API', $response->getStatusCode());
         }
 
+        if(!$data){
+            throw new Exception\Request('no message found for `' . $id . '`');
+        }
 
         switch($data['type']){
             case 'MT':


### PR DESCRIPTION
As the endpoint does not respond with JSON on a 429, parsing the
response does not work and we incorrectly report that no message
exists. This change checks the HTTP code before attempting to inspect
the data and returns the relevant exception if needed

Resolves #12 