### PR TITLE
Add ability to list account numbers

### DIFF
--- a/test/Numbers/ClientTest.php
+++ b/test/Numbers/ClientTest.php
@@ -140,8 +140,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             return true;
         }))->willReturn($this->getResponse('single'));
 
-        $number = $this->numberClient->get($payload);
+        $numbers = $this->numberClient->get($payload);
+        $number = $numbers[0];
 
+        $this->assertInternalType('array', $numbers);
         $this->assertInstanceOf('Nexmo\Numbers\Number', $number);
         if($payload instanceof Number){
             $this->assertSame($payload, $number);
@@ -157,6 +159,27 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             [new Number('12404284163'), '12404284163'],
         ];
     }
+
+    public function testListNumbers()
+    {
+        $this->nexmoClient->send(Argument::that(function(RequestInterface $request){
+            $this->assertEquals('/account/numbers', $request->getUri()->getPath());
+            $this->assertEquals('rest.nexmo.com', $request->getUri()->getHost());
+            $this->assertEquals('GET', $request->getMethod());
+            return true;
+        }))->willReturn($this->getResponse('list'));
+
+        $numbers = $this->numberClient->get();
+
+        $this->assertInternalType('array', $numbers);
+        $this->assertInstanceOf('Nexmo\Numbers\Number', $numbers[0]);
+        $this->assertInstanceOf('Nexmo\Numbers\Number', $numbers[1]);
+
+        $this->assertSame('12404284163', $numbers[0]->getId());
+        $this->assertSame('12404284199', $numbers[1]->getId());
+    }
+
+
 
     /**
      * Get the API response we'd expect for a call to the API.

--- a/test/Numbers/ClientTest.php
+++ b/test/Numbers/ClientTest.php
@@ -140,10 +140,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             return true;
         }))->willReturn($this->getResponse('single'));
 
-        $numbers = $this->numberClient->get($payload);
-        $number = $numbers[0];
+        $number = $this->numberClient->get($payload);
 
-        $this->assertInternalType('array', $numbers);
         $this->assertInstanceOf('Nexmo\Numbers\Number', $number);
         if($payload instanceof Number){
             $this->assertSame($payload, $number);
@@ -169,14 +167,14 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             return true;
         }))->willReturn($this->getResponse('list'));
 
-        $numbers = $this->numberClient->get();
+        $numbers = $this->numberClient->search();
 
         $this->assertInternalType('array', $numbers);
         $this->assertInstanceOf('Nexmo\Numbers\Number', $numbers[0]);
         $this->assertInstanceOf('Nexmo\Numbers\Number', $numbers[1]);
 
-        $this->assertSame('12404284163', $numbers[0]->getId());
-        $this->assertSame('12404284199', $numbers[1]->getId());
+        $this->assertSame('14155550100', $numbers[0]->getId());
+        $this->assertSame('14155550101', $numbers[1]->getId());
     }
 
 

--- a/test/Numbers/responses/list.json
+++ b/test/Numbers/responses/list.json
@@ -1,0 +1,30 @@
+{
+  "count": 2,
+  "numbers": [
+    {
+      "country": "US",
+      "msisdn": "12404284163",
+      "moHttpUrl": "http://example.com/message",
+      "type": "mobile-lvn",
+      "features": [
+        "VOICE",
+        "SMS"
+      ],
+      "voiceCallbackType": "vxml",
+      "voiceCallbackValue": "http://example.com/voice",
+      "voiceStatusCallbackUrl": "http://example.com/status"
+    },
+    {
+      "country": "US",
+      "msisdn": "12404284199",
+      "moHttpUrl": "http://example.com/second_message",
+      "type": "mobile-lvn",
+      "features": [
+        "VOICE"
+      ],
+      "voiceCallbackType": "vxml",
+      "voiceCallbackValue": "http://example.com/second_voice",
+      "voiceStatusCallbackUrl": "http://example.com/second_status"
+    }
+  ]
+}

--- a/test/Numbers/responses/list.json
+++ b/test/Numbers/responses/list.json
@@ -3,28 +3,28 @@
   "numbers": [
     {
       "country": "US",
-      "msisdn": "12404284163",
-      "moHttpUrl": "http://example.com/message",
+      "msisdn": "14155550100",
+      "moHttpUrl": "https://example.com/message",
       "type": "mobile-lvn",
       "features": [
         "VOICE",
         "SMS"
       ],
       "voiceCallbackType": "vxml",
-      "voiceCallbackValue": "http://example.com/voice",
-      "voiceStatusCallbackUrl": "http://example.com/status"
+      "voiceCallbackValue": "https://example.com/voice",
+      "voiceStatusCallbackUrl": "https://example.com/status"
     },
     {
       "country": "US",
-      "msisdn": "12404284199",
-      "moHttpUrl": "http://example.com/second_message",
+      "msisdn": "14155550101",
+      "moHttpUrl": "https://example.com/second_message",
       "type": "mobile-lvn",
       "features": [
         "VOICE"
       ],
       "voiceCallbackType": "vxml",
-      "voiceCallbackValue": "http://example.com/second_voice",
-      "voiceStatusCallbackUrl": "http://example.com/second_status"
+      "voiceCallbackValue": "https://example.com/second_voice",
+      "voiceStatusCallbackUrl": "https://example.com/second_status"
     }
   ]
 }


### PR DESCRIPTION
When searching for numbers, I'd expect to receive a list of matching numbers rather than a single number instance. It's especially misleading at the moment as if multiple numbers match, we return a 404 and say that there are no matching numbers.

There's a more comprehensive discussion going on at https://github.com/Nexmo/nexmo-php/pull/27, but this solves the immediate issue of being able to list all numbers owned by an account by adding a new `::search` method

Resolves #23