### PR TITLE
Rename SharedSecret to SignatureSecret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+This is a high level list of changes for each version of the Nexmo PHP client. 
+
+### 1.0.0 (Not released yet) [Show Diff](https://github.com/Nexmo/nexmo-php/compare/develop)
+
+* Renamed `Nexmo\Client\Credentials\SharedSecret` to `Nexmo\Client\Credentials\SignatureSecret` [#39](https://github.com/Nexmo/nexmo-php/pull/39)
+* Added ability to set callback URL via `setCallback()` [#34](https://github.com/Nexmo/nexmo-php/pull/34)
+* Rate limit error when searching messages [#37](https://github.com/Nexmo/nexmo-php/pull/37)

--- a/src/Client.php
+++ b/src/Client.php
@@ -13,7 +13,7 @@ use Nexmo\Client\Credentials\Container;
 use Nexmo\Client\Credentials\CredentialsInterface;
 use Nexmo\Client\Credentials\Keypair;
 use Nexmo\Client\Credentials\OAuth;
-use Nexmo\Client\Credentials\SharedSecret;
+use Nexmo\Client\Credentials\SignatureSecret;
 use Nexmo\Client\Factory\FactoryInterface;
 use Nexmo\Client\Factory\MapFactory;
 use Nexmo\Client\Response\Response;
@@ -76,7 +76,7 @@ class Client
         $this->setHttpClient($client);
 
         //make sure we know how to use the credentials
-        if(!($credentials instanceof Container) && !($credentials instanceof Basic) && !($credentials instanceof SharedSecret) && !($credentials instanceof OAuth)){
+        if(!($credentials instanceof Container) && !($credentials instanceof Basic) && !($credentials instanceof SignatureSecret) && !($credentials instanceof OAuth)){
             throw new \RuntimeException('unknown credentials type: ' . get_class($credentials));
         }
 
@@ -135,7 +135,7 @@ class Client
      * @param Signature $signature
      * @return RequestInterface
      */
-    public static function signRequest(RequestInterface $request, SharedSecret $credentials)
+    public static function signRequest(RequestInterface $request, SignatureSecret $credentials)
     {
         switch($request->getHeaderLine('content-type')){
             case 'application/json':
@@ -144,7 +144,7 @@ class Client
                 $content = $body->getContents();
                 $params = json_decode($content, true);
                 $params['api_key'] = $credentials['api_key'];
-                $signature = new Signature($params, $credentials['shared_secret']);
+                $signature = new Signature($params, $credentials['signature_secret']);
                 $body->rewind();
                 $body->write(json_encode($signature->getSignedParams()));
                 break;
@@ -155,7 +155,7 @@ class Client
                 $params = [];
                 parse_str($content, $params);
                 $params['api_key'] = $credentials['api_key'];
-                $signature = new Signature($params, $credentials['shared_secret']);
+                $signature = new Signature($params, $credentials['signature_secret']);
                 $params = $signature->getSignedParams();
                 $body->rewind();
                 $body->write(http_build_query($params, null, '&'));
@@ -164,7 +164,7 @@ class Client
                 $query = [];
                 parse_str($request->getUri()->getQuery(), $query);
                 $query['api_key'] = $credentials['api_key'];
-                $signature = new Signature($query, $credentials['shared_secret']);
+                $signature = new Signature($query, $credentials['signature_secret']);
                 $request = $request->withUri($request->getUri()->withQuery(http_build_query($signature->getSignedParams())));
                 break;
         }
@@ -221,7 +221,7 @@ class Client
             }
         } elseif($this->credentials instanceof Keypair){
             $request = $request->withHeader('Authorization', 'Bearer ' . $this->credentials->get(Keypair::class)->generateJwt());
-        } elseif($this->credentials instanceof SharedSecret){
+        } elseif($this->credentials instanceof SignatureSecret){
             $request = self::signRequest($request, $this->credentials);
         } elseif($this->credentials instanceof Basic){
             $request = self::authRequest($request, $this->credentials);

--- a/src/Client/Credentials/Container.php
+++ b/src/Client/Credentials/Container.php
@@ -12,7 +12,7 @@ class Container extends AbstractCredentials implements CredentialsInterface
 {
     protected $types = [
         Basic::class,
-        SharedSecret::class,
+        SignatureSecret::class,
         Keypair::class
     ];
 

--- a/src/Client/Credentials/SignatureSecret.php
+++ b/src/Client/Credentials/SignatureSecret.php
@@ -8,7 +8,7 @@
 
 namespace Nexmo\Client\Credentials;
 
-class SharedSecret extends AbstractCredentials implements CredentialsInterface
+class SignatureSecret extends AbstractCredentials implements CredentialsInterface
 {
     /**
      * Create a credential set with an API key and shared secret.
@@ -19,6 +19,6 @@ class SharedSecret extends AbstractCredentials implements CredentialsInterface
     public function __construct($key, $secret)
     {
         $this->credentials['api_key'] = $key;
-        $this->credentials['shared_secret'] = $secret;
+        $this->credentials['signature_secret'] = $secret;
     }
 }

--- a/src/Client/Credentials/SignatureSecret.php
+++ b/src/Client/Credentials/SignatureSecret.php
@@ -11,14 +11,14 @@ namespace Nexmo\Client\Credentials;
 class SignatureSecret extends AbstractCredentials implements CredentialsInterface
 {
     /**
-     * Create a credential set with an API key and shared secret.
+     * Create a credential set with an API key and signature secret.
      *
      * @param string $key    API Key
-     * @param string $secret Shared Secret
+     * @param string $signature_secret Signature Secret
      */
-    public function __construct($key, $secret)
+    public function __construct($key, $signature_secret)
     {
         $this->credentials['api_key'] = $key;
-        $this->credentials['signature_secret'] = $secret;
+        $this->credentials['signature_secret'] = $signature_secret;
     }
 }

--- a/test/Client/Credentials/ContainerTest.php
+++ b/test/Client/Credentials/ContainerTest.php
@@ -13,14 +13,14 @@ use Nexmo\Client\Credentials\Container;
 use Nexmo\Client\Credentials\Keypair;
 use Nexmo\Client\Credentials\Basic;
 use Nexmo\Client\Credentials\OAuth;
-use Nexmo\Client\Credentials\SharedSecret;
+use Nexmo\Client\Credentials\SignatureSecret;
 use Webmozart\Expression\Selector\Key;
 
 class ContainerTest extends \PHPUnit_Framework_TestCase
 {
     protected $types = [
         Basic::class,
-        SharedSecret::class,
+        SignatureSecret::class,
         Keypair::class
     ];
 
@@ -31,7 +31,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->basic = new Basic('key', 'secret');
-        $this->secret = new SharedSecret('key', 'secret');
+        $this->secret = new SignatureSecret('key', 'secret');
         $this->keypair = new Keypair('key', 'app');
     }
 
@@ -80,7 +80,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [new Basic('key', 'secret'), Basic::class],
-            [new SharedSecret('key', 'secret'), SharedSecret::class],
+            [new SignatureSecret('key', 'secret'), SignatureSecret::class],
             [new Keypair('key', 'app'), Keypair::class]
         ];
     }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -37,7 +37,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     protected $api_key    = 'key12345';
     protected $api_secret = 'secret12345';
 
-    protected $sharedsecret;
+    protected $signature_secret;
     protected $basic;
     protected $key;
     protected $container;
@@ -46,10 +46,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $this->http         = $this->getMockHttp();
         $this->request      = $this->getRequest();
-        $this->sharedsecret = new Client\Credentials\SharedSecret($this->api_key, $this->secret);
+        $this->signature_secret = new Client\Credentials\SignatureSecret($this->api_key, $this->secret);
         $this->basic        = new Client\Credentials\Basic($this->api_key, $this->api_secret);
         $this->key          = new Client\Credentials\Keypair(file_get_contents(__DIR__  . '/Client/Credentials/test.key', 'app'));
-        $this->container    = new Client\Credentials\Container($this->key, $this->basic, $this->sharedsecret);
+        $this->container    = new Client\Credentials\Container($this->key, $this->basic, $this->signature_secret);
     }
 
     public function testBasicCredentialsQuery()
@@ -159,7 +159,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testSignQueryString()
     {
         $request = $this->getRequest();
-        $signed = Client::signRequest($request, $this->sharedsecret);
+        $signed = Client::signRequest($request, $this->signature_secret);
 
         $query = [];
         parse_str($signed->getUri()->getQuery(), $query);
@@ -172,7 +172,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testSignBodyData()
     {
         $request = $this->getRequest('form');
-        $signed = Client::signRequest($request, $this->sharedsecret);
+        $signed = Client::signRequest($request, $this->signature_secret);
 
         $data = [];
         $signed->getBody()->rewind();
@@ -189,7 +189,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testSignJsonData()
     {
         $request = $this->getRequest('json');
-        $signed = Client::signRequest($request, $this->sharedsecret);
+        $signed = Client::signRequest($request, $this->signature_secret);
 
         $signed->getBody()->rewind();
         $data = json_decode($signed->getBody()->getContents(), true);
@@ -205,7 +205,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testBodySignatureDoesNotChangeQuery()
     {
-        $client = new Client($this->sharedsecret, [], $this->http);
+        $client = new Client($this->signature_secret, [], $this->http);
         $request = $this->getRequest('json');
 
         $client->send($request);
@@ -213,9 +213,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($request->getUri()->getQuery());
     }
 
-    public function testSharedSecret()
+    public function testsignature_secret()
     {
-        $client = new Client($this->sharedsecret, [], $this->http);
+        $client = new Client($this->signature_secret, [], $this->http);
 
         //check that signature is now added to request
         $client->send(new Request('http://example.com?test=value'));


### PR DESCRIPTION
**This is a BREAKING CHANGE**

We could alias `SignatureSecret` to `SharedSecret`, but as we're pre-1.0 that feels like something we'd just have to maintain going forwards. Provided we write a good `CHANGELOG.md` I don't see any issue with renaming this

---

This is the name that's used on the customer dashboard for this authentication method.

Resolves #4