### PR TITLE
Support for application/json on InboundMessage

### DIFF
--- a/src/Message/InboundMessage.php
+++ b/src/Message/InboundMessage.php
@@ -71,9 +71,18 @@ class InboundMessage implements MessageInterface, \ArrayAccess
             throw new \RuntimeException('inbound message request should only ever be `' . ServerRequestInterface::class . '`');
         }
 
+        // Check our incoming content type
+        $isApplicationJson = false;
+        $contentTypes = $request->getHeader('Content-Type');
+        // We only respect application/json if it's the first entry without any preference weighting
+        // as that's what Nexmo send
+        if (count($contentTypes) && $contentTypes[0] === 'application/json') {
+            $isApplicationJson = true;
+        }
+
         switch($request->getMethod()){
             case 'POST':
-                $params = $request->getParsedBody();
+                $params = $isApplicationJson ? json_decode((string)$request->getBody(), true) : $request->getParsedBody();
                 break;
             case 'GET':
                 $params = $request->getQueryParams();

--- a/test/Message/InboundMessageTest.php
+++ b/test/Message/InboundMessageTest.php
@@ -133,8 +133,9 @@ class InboundMessageTest extends \PHPUnit_Framework_TestCase
     public function getRequests()
     {
         return [
-            [$this->getServerRequest('https://ohyt2ctr9l0z.runscope.net/sms_post', 'POST', 'inbound')],
-            [$this->getServerRequest('https://ohyt2ctr9l0z.runscope.net/sms_post', 'GET',  'inbound')],
+            'post, application/json' => [$this->getServerRequest('https://ohyt2ctr9l0z.runscope.net/sms_post', 'POST', 'json', ['Content-Type' => 'application/json'])],
+            'post, form-encoded' => [$this->getServerRequest('https://ohyt2ctr9l0z.runscope.net/sms_post', 'POST', 'inbound')],
+            'get, form-encoded' => [$this->getServerRequest('https://ohyt2ctr9l0z.runscope.net/sms_post', 'GET',  'inbound')],
         ];
     }
 
@@ -144,7 +145,7 @@ class InboundMessageTest extends \PHPUnit_Framework_TestCase
      * @param null $file
      * @return ServerRequest
      */
-    protected function getServerRequest($url = 'https://ohyt2ctr9l0z.runscope.net/sms_post', $method = 'GET', $type = 'inbound')
+    protected function getServerRequest($url = 'https://ohyt2ctr9l0z.runscope.net/sms_post', $method = 'GET', $type = 'inbound', $headers = [])
     {
         $data = file_get_contents(__DIR__ . '/requests/' . $type . '.txt');
         $params = [];
@@ -162,10 +163,14 @@ class InboundMessageTest extends \PHPUnit_Framework_TestCase
                 $body = fopen(__DIR__ . '/requests/' . $type . '.txt', 'r');
                 $query = [];
                 $parsed = $params;
+                if (isset($headers['Content-Type']) && $headers['Content-Type'] === 'application/json')
+                {
+                    $parsed = null;
+                }
                 break;
         }
 
-        return new ServerRequest([], [], $url, $method, $body, [], [], $query, $parsed);
+        return new ServerRequest([], [], $url, $method, $body, $headers, [], $query, $parsed);
     }
 
     /**

--- a/test/Message/requests/json.txt
+++ b/test/Message/requests/json.txt
@@ -1,0 +1,1 @@
+{"msisdn":"14845552121","to":"16105553939","messageId":"02000000DA7C52E7","text":"Test this.","type":"text","keyword":"TEST","message-timestamp":"2016-05-24 11:12:01","timestamp":"1464088321","nonce":"51a87f47-476f-447c-bffe-c18600fd12ad","sig":"8cfbb03967d8d6339c82736d7781a7fd"}


### PR DESCRIPTION
A content type of `application/json` with a JSON POST body is now supported for the voice endpoints. This PR updates `nexmo-php` to detect if the `Content-Type` is `application/json` (exactly that, not somewhere in a list and not with a qualifier) and read `php://input` if so.

Resolves #33 