### PR TITLE
Add helper methods for GET/POST/PUT/DELETE

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -22,6 +22,7 @@ use Nexmo\Entity\EntityInterface;
 use Nexmo\Verify\Verification;
 use Psr\Http\Message\RequestInterface;
 use Zend\Diactoros\Uri;
+use Zend\Diactoros\Request;
 
 /**
  * Nexmo API Client, allows access to the API from PHP.
@@ -206,6 +207,83 @@ class Client
     }
     
     /**
+     * Takes a URL and a key=>value array to generate a GET PSR-7 request object
+     *
+     * @param string $url The URL to make a request to
+     * @param array $params Key=>Value array of data to use as the query string
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function get($url, array $params = [])
+    {
+       $queryString = '?' . http_build_query($params);
+
+       $url = $url . $queryString;
+
+       $request = new Request(
+            $url,
+            'GET'
+        );
+
+        return $this->send($request);
+    }
+
+    /**
+     * Takes a URL and a key=>value array to generate a POST PSR-7 request object
+     *
+     * @param string $url The URL to make a request to
+     * @param array $params Key=>Value array of data to send
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function post($url, array $params)
+    {
+        $request = new Request(
+            $url,
+            'POST',
+            'php://temp',
+            ['content-type' => 'application/json']
+        );
+
+        $request->getBody()->write(json_encode($params));
+        return $this->send($request);
+    }
+
+    /**
+     * Takes a URL and a key=>value array to generate a PUT PSR-7 request object
+     *
+     * @param string $url The URL to make a request to
+     * @param array $params Key=>Value array of data to send
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function put($url, array $params)
+    {
+        $request = new Request(
+            $url,
+            'PUT',
+            'php://temp',
+            ['content-type' => 'application/json']
+        );
+
+        $request->getBody()->write(json_encode($params));
+        return $this->send($request);
+    }
+
+    /**
+     * Takes a URL and a key=>value array to generate a DELETE PSR-7 request object
+     *
+     * @param string $url The URL to make a request to
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function delete($url)
+    {
+        $request = new Request(
+            $url,
+            'DELETE'
+        );
+
+        return $this->send($request);
+    }
+
+     /**
      * Wraps the HTTP Client, creates a new PSR-7 request adding authentication, signatures, etc.
      *
      * @param \Psr\Http\Message\RequestInterface $request

--- a/test/Psr7AssertionTrait.php
+++ b/test/Psr7AssertionTrait.php
@@ -13,6 +13,19 @@ use Psr\Http\Message\RequestInterface;
 
 trait Psr7AssertionTrait
 {
+    public static function assertRequestMethod($expected, RequestInterface $request)
+    {
+        self::assertEquals($expected, $request->getMethod());
+    }
+
+    public static function assertRequestBodyIsEmpty(RequestInterface $request)
+    {
+        $request->getBody()->rewind();
+        $body = $request->getBody()->getContents();
+        $request->getBody()->rewind();
+        self::assertEmpty($body);
+    }
+
     public static function assertRequestBodyIsJson($expected, RequestInterface $request)
     {
         $request->getBody()->rewind();
@@ -69,5 +82,14 @@ trait Psr7AssertionTrait
     public static function assertRequestMatchesUrl($url, RequestInterface $request)
     {
         self::assertEquals($url, $request->getUri()->withQuery('')->__toString(), 'url did not match request');
+    }
+
+    public static function assertRequestMatchesUrlWithQueryString($url, RequestInterface $request)
+    {
+        $query = [];
+        parse_str($request->getUri()->getQuery(), $query);
+        unset($query['api_key'], $query['api_secret']);
+        $query = http_build_query($query);
+        self::assertEquals($url, $request->getUri()->withQuery($query)->__toString(), 'url did not match request');
     }
 }


### PR DESCRIPTION
These are available for use in the situation that Nexmo add new API
endpoints, but the customer cannot upgrade their library. By reusing
the existing `Client::send` method, we add authentication etc for free.

The desired way to implement this would be for consumers to create
their own `Zend\Diactoros\Request` (or anything that is
`Psr\Http\Message\RequestInterface` compatible) objects to pass to
`Client::send`. This option is still available - these new methods are
for those that want a quick way to get moving.