### PR TITLE
When making a voice call, only the Keypair auth is required

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -76,7 +76,7 @@ class Client
         $this->setHttpClient($client);
 
         //make sure we know how to use the credentials
-        if(!($credentials instanceof Container) && !($credentials instanceof Basic) && !($credentials instanceof SignatureSecret) && !($credentials instanceof OAuth)){
+        if(!($credentials instanceof Container) && !($credentials instanceof Basic) && !($credentials instanceof SignatureSecret) && !($credentials instanceof OAuth) && !($credentials instanceof Keypair)){
             throw new \RuntimeException('unknown credentials type: ' . get_class($credentials));
         }
 
@@ -220,7 +220,7 @@ class Client
                 $request = self::authRequest($request, $this->credentials->get(Basic::class));
             }
         } elseif($this->credentials instanceof Keypair){
-            $request = $request->withHeader('Authorization', 'Bearer ' . $this->credentials->get(Keypair::class)->generateJwt());
+            $request = $request->withHeader('Authorization', 'Bearer ' . $this->credentials->generateJwt());
         } elseif($this->credentials instanceof SignatureSecret){
             $request = self::signRequest($request, $this->credentials);
         } elseif($this->credentials instanceof Basic){

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -122,6 +122,20 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete('not yet implemented');
     }
 
+    public function testKeypairCredentials()
+    {
+        $client = new Client($this->key_credentials, [], $this->http);
+        $request = $this->getRequest('json');
+
+        $client->send($request);
+
+        $request = $this->http->getRequests()[0];
+        $this->assertEmpty($request->getUri()->getQuery());
+        $auth = $request->getHeaderLine('Authorization');
+        $this->assertStringStartsWith('Bearer ', $auth);
+        $this->markTestIncomplete('Has correct format, but not tested as output of JWT generation');
+    }
+
     public function testSettingBaseUrl()
     {
         $client = new Client(new Basic('key', 'secret'), [


### PR DESCRIPTION
This commit adds `Keypair` to the list of valid credential types
and fixes a bug where we call `->get()` before generating the JWT
when `$this->credentials` is already the Keypair credential type