### PR TITLE
Handle `title` and `error_title` inconsistency in voice API

### DIFF
--- a/src/Call/Collection.php
+++ b/src/Call/Collection.php
@@ -144,10 +144,25 @@ class Collection implements ClientAwareInterface, CollectionInterface, \ArrayAcc
         $body = json_decode($response->getBody()->getContents(), true);
         $status = $response->getStatusCode();
 
+        // Error responses aren't consistent. Some are generated within the
+        // proxy and some are generated within voice itself. This handles
+        // both cases
+
+        // This message isn't very useful, but we shouldn't ever see it
+        $errorTitle = 'Unexpected error';
+
+        if (isset($body['title'])) {
+            $errorTitle = $body['title'];
+        }
+
+        if (isset($body['error_title'])) {
+            $errorTitle = $body['error_title'];
+        }
+
         if($status >= 400 AND $status < 500) {
-            $e = new Exception\Request($body['error_title'], $status);
+            $e = new Exception\Request($errorTitle, $status);
         } elseif($status >= 500 AND $status < 600) {
-            $e = new Exception\Server($body['error_title'], $status);
+            $e = new Exception\Server($errorTitle, $status);
         } else {
             $e = new Exception\Exception('Unexpected HTTP Status Code');
             throw $e;

--- a/test/Call/responses/error_proxy.json
+++ b/test/Call/responses/error_proxy.json
@@ -1,0 +1,5 @@
+{
+    "type": "UNSUPPORTED_MEDIA_TYPE",
+    "error_title": "Unsupported Media Type"
+}
+

--- a/test/Call/responses/error_unknown_format.json
+++ b/test/Call/responses/error_unknown_format.json
@@ -1,0 +1,3 @@
+{
+    "msg_error": "Unexpected error"
+}

--- a/test/Call/responses/error_vapi.json
+++ b/test/Call/responses/error_vapi.json
@@ -1,0 +1,7 @@
+{
+    "type": 400,
+    "title": "Bad Request",
+    "invalid_parameters": [
+        { "reason": "can contain up to 15 digits prefixed with +", "name": "number" }
+    ]
+}


### PR DESCRIPTION
The requests can be handled by different services which have
different error formats. This commit reads both error fields and
provides a fallback if neither can be found

Resolves #36 