### PR TITLE
Download recordings using $client->get()

### DIFF
--- a/examples/fetch_recording.php
+++ b/examples/fetch_recording.php
@@ -1,0 +1,12 @@
+<?php
+
+require_once "vendor/autoload.php";
+
+$recordingId = 'RECORDING_ID';
+
+$keypair = new \Nexmo\Client\Credentials\Keypair(file_get_contents(__DIR__ . '/private.key'), 'APPLICATION_ID');
+$client = new \Nexmo\Client($keypair);
+$recording = 'https://api.nexmo.com/v1/files/'.$recordingId;
+$data = $client->get($recording);
+
+file_put_contents($recordingId.'.mp3', $data->getBody());

--- a/src/Client.php
+++ b/src/Client.php
@@ -292,7 +292,7 @@ class Client
     public function send(\Psr\Http\Message\RequestInterface $request)
     {
         if($this->credentials instanceof Container) {
-            if (strpos($request->getUri()->getPath(), '/v1/calls') === 0) {
+            if ($this->needsKeypairAuthentication($request)) {
                 $request = $request->withHeader('Authorization', 'Bearer ' . $this->credentials->get(Keypair::class)->generateJwt());
             } else {
                 $request = self::authRequest($request, $this->credentials->get(Basic::class));
@@ -374,5 +374,14 @@ class Client
         }
 
         return $this->factory->getApi($name);
+    }
+
+    protected function needsKeypairAuthentication(\Psr\Http\Message\RequestInterface $request)
+    {
+        $path = $request->getUri()->getPath();
+        $isCallEndpoint = strpos($path, '/v1/calls') === 0;
+        $isRecordingUrl = strpos($path, '/v1/files') === 0;
+
+        return $isCallEndpoint || $isRecordingUrl;
     }
 }

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -103,6 +103,20 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->markTestIncomplete('Has correct format, but not tested as output of JWT generation');
     }
 
+    public function testCredentialContainerUsesKeypairForFiles()
+    {
+        $client = new Client($this->container, [], $this->http);
+        $request = $this->getRequest('query', [], 'https://api.nexmo.com/v1/files/AB-12-DC-34');
+
+        $client->send($request);
+
+        $request = $this->http->getRequests()[0];
+        $this->assertEmpty($request->getUri()->getQuery());
+        $auth = $request->getHeaderLine('Authorization');
+        $this->assertStringStartsWith('Bearer ', $auth);
+        $this->markTestIncomplete('Has correct format, but not tested as output of JWT generation');
+    }
+
     public function testBasicCredentialsJson()
     {
         $client = new Client($this->basic_credentials, [], $this->http);


### PR DESCRIPTION
As there's no way to fetch a list of recordings for a given call
yet, we can't add `::downloadRecording()` as a method on a call
object.

This PR adds the ability to download recordings using the generic
`client::get()` method by detecting if the request is to a
`/v1/file` endpoint and using Bearer auth if so.

Resolves #44