### PR TITLE
Search numbers available to purchase

### DIFF
--- a/test/Numbers/responses/available-numbers.json
+++ b/test/Numbers/responses/available-numbers.json
@@ -1,0 +1,24 @@
+{
+  "count": 94441,
+  "numbers": [
+    {
+      "country": "US",
+      "msisdn": "14155550100",
+      "cost": "0.67",
+      "type": "mobile-lvn",
+      "features": [
+        "VOICE",
+        "SMS"
+      ]
+    },
+    {
+      "country": "US",
+      "msisdn": "14155550101",
+      "cost": "0.67",
+      "type": "mobile-lvn",
+      "features": [
+        "VOICE"
+      ]
+    }
+  ]
+}

--- a/test/Psr7AssertionTrait.php
+++ b/test/Psr7AssertionTrait.php
@@ -42,6 +42,14 @@ trait Psr7AssertionTrait
         self::assertEquals($method, $request->getMethod());
     }
 
+    public static function assertRequestQueryNotContains($key, $value, RequestInterface $request)
+    {
+        $query = $request->getUri()->getQuery();
+        $params = [];
+        parse_str($query, $params);
+        self::assertArrayNotHasKey($key, $params, 'query string has key when it should not: ' . $key);
+    }
+
     public static function assertRequestQueryContains($key, $value, RequestInterface $request)
     {
         $query = $request->getUri()->getQuery();


### PR DESCRIPTION
This commit deprecates `Numbers::search` in favour of
`Numbers::searchOwned` to make it clear when you're searching your own
numbers or those which are available.

When searching available numbers, there is a whitelist of supported
query parameters, via
https://developer.nexmo.com/api/developer/numbers#search-available-numbers

* pattern
* search_pattern
* features
* size
* index

Resolves #54