### PR TITLE
Support for purchasing a number

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ API Coverage
     * [ ] Top Up
     * [X] Numbers
         * [X] Search
-        * [ ] Buy
+        * [X] Buy
         * [ ] Cancel
         * [X] Update
 * Number Insight

--- a/test/Numbers/responses/method-failed.json
+++ b/test/Numbers/responses/method-failed.json
@@ -1,0 +1,4 @@
+{
+  "error-code": "420",
+  "error-code-label": "method failed"
+}


### PR DESCRIPTION
At the moment we can't distinguish why a purchase has failed, so we
just pass the server error back to the user.

When a number is successfully purchased, there's no useful information
in the response. We could perform a `GET` on the number and return an
object but it feels a little heavy handed.

For now, the method doesn't return anything, and throws exceptions on
any errors. If the method call succeeds, we purchased the number
successfully

Resolves #55