### PR TITLE
Add support for cancelling purchased numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 composer.lock
 vendor
+logs

--- a/test/Numbers/NumberTest.php
+++ b/test/Numbers/NumberTest.php
@@ -45,7 +45,7 @@ class NumberTest extends \PHPUnit_Framework_TestCase
         $this->number->jsonUnserialize($data['numbers'][0]);
 
         $this->assertEquals('US', $this->number->getCountry());
-        $this->assertEquals('12404284163', $this->number->getNumber());
+        $this->assertEquals('1415550100', $this->number->getNumber());
         $this->assertEquals(Number::TYPE_MOBILE, $this->number->getType());
 
         $this->assertEquals('http://example.com/message', $this->number->getWebhook(Number::WEBHOOK_MESSAGE));

--- a/test/Numbers/responses/cancel.json
+++ b/test/Numbers/responses/cancel.json
@@ -1,0 +1,4 @@
+{
+  "error-code": "200",
+  "error-code-label": "success"
+}

--- a/test/Numbers/responses/single.json
+++ b/test/Numbers/responses/single.json
@@ -3,7 +3,7 @@
   "numbers": [
     {
       "country": "US",
-      "msisdn": "12404284163",
+      "msisdn": "1415550100",
       "moHttpUrl": "http://example.com/message",
       "type": "mobile-lvn",
       "features": [


### PR DESCRIPTION
This also updates the tests to use a 555 number so we don't
accidentally interact with a real person.

Purchasing a number can now be done by providing just a number (the
same as cancelling a number). This is done by making an additional GET
request

Resolves #57 