### PR TITLE
Support 204 response from PUT /call in addition to 200

### DIFF
--- a/src/Call/Call.php
+++ b/src/Call/Call.php
@@ -113,7 +113,8 @@ class Call implements EntityInterface, \JsonSerializable, JsonUnserializableInte
         $request->getBody()->write(json_encode($payload));
         $response = $this->client->send($request);
 
-        if($response->getStatusCode() != '200'){
+        $responseCode = $response->getStatusCode();
+        if($responseCode != '200' && $responseCode != '204'){
             throw $this->getException($response);
         }
 

--- a/test/Call/CallTest.php
+++ b/test/Call/CallTest.php
@@ -91,7 +91,7 @@ class CallTest extends \PHPUnit_Framework_TestCase
      * @param $payload
      * @dataProvider putCall
      */
-    public function testPutMakesRequest($payload)
+    public function testPutMakesRequest($payload, $expectedHttpCode, $expectedResponse)
     {
         $id = $this->id;
         $expected = json_decode(json_encode($payload), true);
@@ -106,7 +106,7 @@ class CallTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals($expected, $body);
 
             return true;
-        }))->willReturn($this->getResponse('updated'));
+        }))->willReturn($this->getResponse($expectedResponse, $expectedHttpCode));
 
         $this->entity->put($payload);
     }
@@ -126,8 +126,9 @@ class CallTest extends \PHPUnit_Framework_TestCase
         ];
 
         return [
-            [$transfer],
-            [new Transfer('http://example.com')]
+            [$transfer, 200, 'updated'],
+            [new Transfer('http://example.com'), 200, 'updated'],
+            [new Transfer('http://example.com'), 204, 'empty']
         ];
     }
 


### PR DESCRIPTION
This is related to a voice API bug. The endpoint may revert to
returning data in future with a 200 response, so we need to support
both HTTP codes simultaneously