### PR TITLE
Add support for Secret Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,36 @@ Or you can specify the number and country manually
 $client->numbers()->purchase('14155550100', 'US');
 ```
 
+### Managing Secrets
+
+An API is provided to allow you to rotate your API secrets. You can create a new secret (up to a maximum of two secrets) and delete the existing one once all applications have been updated.
+
+Get a list of the secrets:
+
+```php
+$secretCollection = $client->account()->listSecrets(API_KEY);
+
+foreach($secretCollection['secrets'] as $secret) {
+    echo "ID: " . $secret['id'] . " (created " . $secret['created_at'] .")\n";
+}
+```
+
+Create a new secret (the created dates will help you know which is which):
+
+```php
+$client->account()->createSecret(API_KEY, 'awes0meNewSekret!!;');
+```
+
+Delete the old secret (any application still using these credentials will stop working):
+
+```php
+try {
+    $response = $client->account()->deleteSecret(API_KEY, 'd0f40c7e-91f2-4fe0-8bc6-8942587b622c');
+} catch(\Nexmo\Client\Exception\Request $e) {
+    echo $e->getMessage();
+}
+```
+
 ## Troubleshooting
 
 Some users have issues making requests due to the following error:
@@ -400,7 +430,6 @@ curl.cainfo = "/etc/pki/tls/cacert.pem"
 curl.cainfo = "C:\php\extras\ssl\cacert.pem"
 ```
 
-    
 API Coverage
 ------------
 
@@ -409,6 +438,7 @@ API Coverage
     * [X] Pricing
     * [ ] Settings
     * [ ] Top Up
+    * [X] Secret Management
     * [X] Numbers
         * [X] Search
         * [X] Buy

--- a/src/Account/Client.php
+++ b/src/Account/Client.php
@@ -2,6 +2,7 @@
 
 namespace Nexmo\Account;
 
+use Nexmo\ApiErrorHandler;
 use Nexmo\Client\ClientAwareInterface;
 use Nexmo\Client\ClientAwareTrait;
 use Nexmo\Network;
@@ -93,6 +94,78 @@ class Client implements ClientAwareInterface
         if($response->getStatusCode() != '200'){
             throw $this->getException($response, $application);
         }
+    }
+
+    public function listSecrets($apiKey)
+    {
+        $body = $this->get( \Nexmo\Client::BASE_API . '/accounts/'.$apiKey.'/secrets');
+        return SecretCollection::fromApi($body);
+    }
+
+    public function getSecret($apiKey, $secretId)
+    {
+        $body = $this->get( \Nexmo\Client::BASE_API . '/accounts/'.$apiKey.'/secrets/'. $secretId);
+        return Secret::fromApi($body);
+    }
+
+    public function createSecret($apiKey, $newSecret)
+    {
+        $body = [
+            'secret' => $newSecret
+        ];
+
+        $request = new Request(
+            \Nexmo\Client::BASE_API . '/accounts/'.$apiKey.'/secrets'
+            ,'POST'
+            , 'php://temp'
+            , ['content-type' => 'application/json']
+        );
+
+        $request->getBody()->write(json_encode($body));
+        $response = $this->client->send($request);
+
+        $rawBody = $response->getBody()->getContents();
+        $responseBody = json_decode($rawBody, true);
+        ApiErrorHandler::check($responseBody, $response->getStatusCode());
+
+        return Secret::fromApi($responseBody);
+    }
+
+    public function deleteSecret($apiKey, $secretId)
+    {
+        $request = new Request(
+            \Nexmo\Client::BASE_API . '/accounts/'.$apiKey.'/secrets/'. $secretId
+            ,'DELETE'
+            , 'php://temp'
+            , ['content-type' => 'application/json']
+        );
+
+        $response = $this->client->send($request);
+        $rawBody = $response->getBody()->getContents();
+        $body = json_decode($rawBody, true);
+
+        // This will throw an exception on any error
+        ApiErrorHandler::check($body, $response->getStatusCode());
+
+        // This returns a 204, so no response body
+    }
+
+    protected function get($url) {
+       $request = new Request(
+           $url
+           ,'GET'
+           , 'php://temp'
+           , ['content-type' => 'application/json']
+        );
+
+        $response = $this->client->send($request);
+        $rawBody = $response->getBody()->getContents();
+        $body = json_decode($rawBody, true);
+
+        // This will throw an exception on any error
+        ApiErrorHandler::check($body, $response->getStatusCode());
+
+        return $body;
     }
 
     protected function getException(ResponseInterface $response, $application = null)

--- a/src/Account/Secret.php
+++ b/src/Account/Secret.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Nexmo\Account;
+
+use Nexmo\InvalidResponseException;
+
+class Secret implements \ArrayAccess {
+    protected $data;
+
+    public function __construct($data) {
+        $this->data = $data;
+    }
+
+    public function getId() {
+        return $this['id'];
+    }
+
+    public function getCreatedAt() {
+        return $this['created_at'];
+    }
+
+    public function getLinks() {
+        return $this['_links'];
+    }
+
+    public static function fromApi($data) {
+        if (!isset($data['id'])) {
+            throw new InvalidResponseException("Missing key: 'id");
+        }
+        if (!isset($data['created_at'])) {
+            throw new InvalidResponseException("Missing key: 'created_at");
+        }
+        return new self($data);
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->data[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->data[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        throw new \Exception('Secret::offsetSet is not implemented');
+    }
+
+    public function offsetUnset($offset)
+    {
+        throw new \Exception('Secret::offsetUnset is not implemented');
+    }
+
+}

--- a/src/Account/SecretCollection.php
+++ b/src/Account/SecretCollection.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Nexmo\Account;
+
+class SecretCollection implements \ArrayAccess {
+    protected $data;
+
+    public function __construct($secrets, $links) {
+        $this->data = [
+            'secrets' => $secrets,
+            '_links' => $links
+        ];
+    }
+
+    public function getSecrets() {
+        return $this['secrets'];
+    }
+
+    public function getLinks() {
+        return $this['_links'];
+    }
+
+    public static function fromApi($data) {
+        $secrets = [];
+        foreach ($data['_embedded']['secrets'] as $s) {
+            $secrets[] = Secret::fromApi($s);
+        }
+        return new self($secrets, $data['_links']);
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->data[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->data[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        throw new \Exception('SecretCollection::offsetSet is not implemented');
+    }
+
+    public function offsetUnset($offset)
+    {
+        throw new \Exception('SecretCollection::offsetUnset is not implemented');
+    }
+
+}

--- a/src/ApiErrorHandler.php
+++ b/src/ApiErrorHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Nexmo;
+use Nexmo\Client\Exception;
+
+class ApiErrorHandler {
+    public static function check($body, $statusCode) {
+        $statusCodeType = (int) ($statusCode / 100);
+
+        // If it's ok, we can continue
+        if ($statusCodeType == 2) {
+            return;
+        }
+
+        // Build up our error message
+        $errorMessage = $body['title'];
+        if (isset($body['detail']) && $body['detail']) {
+            $errorMessage .= ': '.$body['detail'].'.';
+        } else {
+            $errorMessage .= '.';
+        }
+
+        $errorMessage .= ' See '.$body['type'].' for more information';
+
+        // If it's a 5xx error, throw an exception
+        if ($statusCodeType == 5) {
+            throw new Exception\Server($errorMessage, $statusCode);
+        }
+
+        // Otherwise it's a 4xx, so we may have more context for the user
+        // If it's a validation error, share that information
+        if (isset($body['invalid_parameters'])) {
+            throw new Exception\Validation($errorMessage, $statusCode, null, $body['invalid_parameters']);
+        }
+
+        // Otherwise throw a normal error
+        throw new Exception\Request($errorMessage, $statusCode);
+    }
+}

--- a/src/Client/Exception/Validation.php
+++ b/src/Client/Exception/Validation.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Nexmo Client Library for PHP
+ *
+ * @copyright Copyright (c) 2016 Nexmo, Inc. (http://nexmo.com)
+ * @license   https://github.com/Nexmo/nexmo-php/blob/master/LICENSE.txt MIT License
+ */
+
+namespace Nexmo\Client\Exception;
+
+use Throwable;
+
+class Validation extends Request
+{
+    public function __construct($message = "", $code = 0, Throwable $previous = null, $errors)
+    {
+        $this->errors = $errors;
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getValidationErrors() {
+        return $this->errors;
+    }
+}

--- a/src/InvalidResponseException.php
+++ b/src/InvalidResponseException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Nexmo;
+
+class InvalidResponseException extends \Exception {
+
+}

--- a/test/Account/SecretCollectionTest.php
+++ b/test/Account/SecretCollectionTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Nexmo Client Library for PHP
+ *
+ * @copyright Copyright (c) 2016 Nexmo, Inc. (http://nexmo.com)
+ * @license   https://github.com/Nexmo/nexmo-php/blob/master/LICENSE.txt MIT License
+ */
+
+namespace NexmoTest\Account;
+
+use Nexmo\Account\Secret;
+use Nexmo\Account\SecretCollection;
+use PHPUnit\Framework\TestCase;
+
+class SecretCollectionTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->secrets = [[
+            'id' => 'ad6dc56f-07b5-46e1-a527-85530e625800',
+            'created_at' => '2017-03-02T16:34:49Z',
+            '_links' => [
+                'self' => [
+                    'href' => '/accounts/abcd1234/secrets/ad6dc56f-07b5-46e1-a527-85530e625800'
+                ]
+            ]
+        ]];
+
+        $this->links = [
+            'self' => [
+                'href' => '/accounts/abcd1234/secrets'
+            ]
+        ];
+
+        $this->collection = SecretCollection::fromApi([
+            '_links' => $this->links,
+            '_embedded' => [
+                'secrets' => $this->secrets
+            ]
+        ]);
+    }
+
+    public function testGetSecrets()
+    {
+        $secrets = $this->collection->getSecrets();
+        $this->assertInstanceOf(Secret::class, $secrets[0]);
+    }
+
+    public function testGetLinks()
+    {
+        $this->assertArrayHasKey('self', $this->collection->getLinks());
+    }
+
+    public function testObjectAccess()
+    {
+        $this->assertEquals($this->links, $this->collection->getLinks());
+
+        $secrets = array_map(function ($v) {
+            return Secret::fromApi($v);
+        }, $this->secrets);
+        $this->assertEquals($secrets, $this->collection->getSecrets());
+    }
+
+    public function testArrayAccess()
+    {
+        $this->assertEquals($this->links, $this->collection['_links']);
+
+        $secrets = array_map(function ($v) {
+            return Secret::fromApi($v);
+        }, $this->secrets);
+        $this->assertEquals($secrets, $this->collection['secrets']);
+    }
+}

--- a/test/Account/SecretTest.php
+++ b/test/Account/SecretTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Nexmo Client Library for PHP
+ *
+ * @copyright Copyright (c) 2016 Nexmo, Inc. (http://nexmo.com)
+ * @license   https://github.com/Nexmo/nexmo-php/blob/master/LICENSE.txt MIT License
+ */
+
+namespace NexmoTest\Account;
+
+use Nexmo\Account\Secret;
+use Nexmo\InvalidResponseException;
+use PHPUnit\Framework\TestCase;
+
+class SecretTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->secret = Secret::fromApi([
+            'id' => 'ad6dc56f-07b5-46e1-a527-85530e625800',
+            'created_at' => '2017-03-02T16:34:49Z',
+            '_links' => [
+                'self' => [
+                    'href' => '/accounts/abcd1234/secrets/ad6dc56f-07b5-46e1-a527-85530e625800'
+                ]
+            ]
+        ]);
+    }
+
+    public function testRejectsInvalidDataNoId()
+    {
+        $this->expectException(InvalidResponseException::class);
+        Secret::fromApi(['id' => 'abc']);
+    }
+
+    public function testRejectsInvalidDataNoCreatedAt()
+    {
+        $this->expectException(InvalidResponseException::class);
+        Secret::fromApi(['created_at' => '2017-03-02T16:34:49Z']);
+    }
+
+    public function testObjectAccess()
+    {
+        $this->assertEquals('ad6dc56f-07b5-46e1-a527-85530e625800', $this->secret->getId());
+        $this->assertEquals('2017-03-02T16:34:49Z', $this->secret->getCreatedAt());
+    }
+
+    public function testArrayAccess()
+    {
+        $this->assertEquals('ad6dc56f-07b5-46e1-a527-85530e625800', $this->secret['id']);
+        $this->assertEquals('2017-03-02T16:34:49Z', $this->secret['created_at']);
+    }
+}

--- a/test/Account/responses/secret-management/create-validation.json
+++ b/test/Account/responses/secret-management/create-validation.json
@@ -1,0 +1,12 @@
+{
+  "type": "https://developer.nexmo.com/api-errors/account/secret-management#validation",
+  "title": "Bad Request",
+  "detail": "The request failed due to validation errors",
+  "invalid_parameters": [
+    {
+      "name": "secret",
+      "reason": "Does not meet complexity requirements"
+    }
+  ],
+  "instance": "797a8f199c45014ab7b08bfe9cc1c12c"
+}

--- a/test/Account/responses/secret-management/create.json
+++ b/test/Account/responses/secret-management/create.json
@@ -1,0 +1,9 @@
+{
+  "_links": {
+    "self": {
+      "href": "/accounts/abcd1234/secrets/ad6dc56f-07b5-46e1-a527-85530e625800"
+    }
+  },
+  "id": "ad6dc56f-07b5-46e1-a527-85530e625800",
+  "created_at": "2017-03-02T16:34:49Z"
+}

--- a/test/Account/responses/secret-management/get.json
+++ b/test/Account/responses/secret-management/get.json
@@ -1,0 +1,9 @@
+{
+  "_links": {
+    "self": {
+      "href": "/accounts/abcd1234/secrets/ad6dc56f-07b5-46e1-a527-85530e625800"
+    }
+  },
+  "id": "ad6dc56f-07b5-46e1-a527-85530e625800",
+  "created_at": "2017-03-02T16:34:49Z"
+}

--- a/test/Account/responses/secret-management/last-secret.json
+++ b/test/Account/responses/secret-management/last-secret.json
@@ -1,0 +1,6 @@
+{
+  "type": "https://developer.nexmo.com/api-errors/account/secret-management#delete-last-secret",
+  "title": "Secret Deletion Forbidden",
+  "detail": "Can not delete the last secret. The account must always have at least 1 secret active at any time",
+  "instance": "797a8f199c45014ab7b08bfe9cc1c12c"
+}

--- a/test/Account/responses/secret-management/list.json
+++ b/test/Account/responses/secret-management/list.json
@@ -1,0 +1,20 @@
+{
+  "_links": {
+    "self": {
+      "href": "/accounts/abcd1234/secrets"
+    }
+  },
+  "_embedded": {
+    "secrets": [
+      {
+        "_links": {
+          "self": {
+            "href": "/accounts/abcd1234/secrets/ad6dc56f-07b5-46e1-a527-85530e625800"
+          }
+        },
+        "id": "ad6dc56f-07b5-46e1-a527-85530e625800",
+        "created_at": "2017-03-02T16:34:49Z"
+      }
+    ]
+  }
+}

--- a/test/Account/responses/secret-management/max-secrets.json
+++ b/test/Account/responses/secret-management/max-secrets.json
@@ -1,0 +1,6 @@
+{
+  "type": "https://developer.nexmo.com/api-errors/account/secret-management#maximum-secrets-allowed",
+  "title": "Maxmimum number of secrets already met",
+  "detail": "This account has reached maximum number of '2' allowed secrets",
+  "instance": "797a8f199c45014ab7b08bfe9cc1c12c"
+}

--- a/test/Account/responses/secret-management/missing.json
+++ b/test/Account/responses/secret-management/missing.json
@@ -1,0 +1,6 @@
+{
+  "type": "https://developer.nexmo.com/api-errors#invalid-api-key",
+  "title": "Invalid API Key",
+  "detail": "API key 'ABC123' does not exist, or you do not have access",
+  "instance": "797a8f199c45014ab7b08bfe9cc1c12c"
+}

--- a/test/Account/responses/secret-management/unauthorized.json
+++ b/test/Account/responses/secret-management/unauthorized.json
@@ -1,0 +1,6 @@
+{
+  "type": "https://developer.nexmo.com/api-errors#unauthorized",
+  "title": "Invalid credentials supplied",
+  "detail": "You did not provide correct credentials.",
+  "instance": "797a8f199c45014ab7b08bfe9cc1c12c"
+}

--- a/test/ApiErrorHandlerTest.php
+++ b/test/ApiErrorHandlerTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace NexmoTest;
+
+use GuzzleHttp\Psr7\Response;
+use Nexmo\Client\Exception\Exception;
+use Nexmo\Client\Exception\Request;
+use Nexmo\Client\Exception\Server;
+use Nexmo\Client\Exception\Validation;
+use PHPUnit\Framework\TestCase;
+use Nexmo\ApiErrorHandler;
+
+class ApiErrorHandlerTest extends TestCase
+{
+    public function testDoesNotThrowOnSuccess()
+    {
+        ApiErrorHandler::check(['success' => true], 200);
+    }
+
+    public function testThrowsOn4xx()
+    {
+       $this->expectException(Request::class);
+       $this->expectExceptionMessage('Maximum number of flibbets met. See http://example.com/error for more information');
+       ApiErrorHandler::check(['type' => 'http://example.com/error', 'title' => 'Maximum number of flibbets met'], 403);
+    }
+
+    public function testThrowsOn4xxWithDetail()
+    {
+       $this->expectException(Request::class);
+       $this->expectExceptionMessage('Maximum number of flibbets met: Only allowed 3. See http://example.com/error for more information');
+       ApiErrorHandler::check(['type' => 'http://example.com/error', 'title' => 'Maximum number of flibbets met', 'detail' => 'Only allowed 3'], 403);
+    }
+
+    public function testThrowsOn400WithValidationErrors()
+    {
+       try {
+           ApiErrorHandler::check([
+               'type' => 'http://example.com/error',
+               'title' => 'Bad Request',
+               'detail' => 'The request failed due to validation errors',
+               'invalid_parameters' => [
+                   [
+                       "name" => "primary_colour",
+                       "reason" => "Must be one of: blue, red, yellow"
+                   ]
+               ]
+           ], 400);
+       } catch (Validation $e) {
+           $this->assertInstanceOf(Validation::class, $e);
+           $this->assertEquals('Bad Request: The request failed due to validation errors. See http://example.com/error for more information', $e->getMessage());
+           $this->assertEquals([
+               [
+                   "name" => "primary_colour",
+                   "reason" => "Must be one of: blue, red, yellow"
+               ]
+           ], $e->getValidationErrors());
+       }
+    }
+
+    public function testThrowsOn5xx()
+    {
+       $this->expectException(Server::class);
+       $this->expectExceptionMessage('Server Error. See http://example.com/error for more information');
+       ApiErrorHandler::check(['type' => 'http://example.com/error', 'title' => 'Server Error'], 500);
+    }
+
+    public function testThrowsOn5xxWithDetail()
+    {
+       $this->expectException(Server::class);
+       $this->expectExceptionMessage('Server Error: More Information. See http://example.com/error for more information');
+       ApiErrorHandler::check(['type' => 'http://example.com/error', 'title' => 'Server Error', 'detail' => 'More Information'], 500);
+    }
+}

--- a/test/responses/general/401.json
+++ b/test/responses/general/401.json
@@ -1,0 +1,6 @@
+{
+  "type": "https://developer.nexmo.com/api-errors#unauthorized",
+  "title": "Invalid credentials supplied",
+  "detail": "You did not provide correct credentials.",
+  "instance": "797a8f199c45014ab7b08bfe9cc1c12c"
+}

--- a/test/responses/general/500.json
+++ b/test/responses/general/500.json
@@ -1,0 +1,6 @@
+{
+  "type": "https://developer.nexmo.com/api-errors#internal-error",
+  "title": "Internal Error",
+  "detail": "An internal error occured. Please try again shortly",
+  "instance": "797a8f199c45014ab7b08bfe9cc1c12c"
+}


### PR DESCRIPTION
This implements the endpoints for the Secret Management API - https://nexmo-developer-staging-pr-579.herokuapp.com/api/account/secret-management

It's the first API that follows RFC7807 for errors (plus our `invalid_parameters` extension for validation errors). To help with this, I've added `ApiErrorHandler::check` which throws formatted exceptions on error.

I've tested `2xx`, `4xx` and `5xx` errors for all of the endpoints, plus an additional test for validation on `createSecret`.

This PR adds two classes, `Secret` and `SecretCollection` for wrapping the API responses. They each have object access and arrayAccess functionality