### PR TITLE
Bump PHPUnit version to force compatibility with other libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "lcobucci/jwt": "^3.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.3",
+    "phpunit/phpunit": "^5.7",
     "php-http/mock-client": "^0.3.0",
     "estahn/phpunit-json-assertions": "@stable",
     "squizlabs/php_codesniffer": "^3.1"


### PR DESCRIPTION
We realised today that if an older version of PHPUnit is installed, it causes issues with one of the other libraries. Require PHPUnit 5.7 as a minimum to avoid this.