### PR TITLE
Add the not-verified outcome to the README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,13 +190,27 @@ In the same way, checking a verification requires the code the user provided, an
 
 ```php
 $verification = new \Nexmo\Verify\Verification('00e6c3377e5348cdaf567e1417c707a5');
-$client->verify()->check($verification, '1234');
+try {
+    $client->verify()->check($verification, '1234');
+    echo "Verification was successful (status: " . $verification['status'] . ")\n";
+} catch (Exception $e) {
+    $verification = $e->getEntity();
+    echo "Verification failed with status " . $verification['status']
+        . " and error text \"" . $verification['error_text'] . "\"\n";
+}
 ```
  
 Or a request ID:
 
 ```php
-$client->verify()->check('00e6c3377e5348cdaf567e1417c707a5', '1234');
+try {
+    $verification = $client->verify()->check('00e6c3377e5348cdaf567e1417c707a5', '1234');
+    echo "Verification was successful (status: " . $verification['status'] . ")\n";
+} catch (Exception $e) {
+    $verification = $e->getEntity();
+    echo "Verification failed with status " . $verification['status']
+        . " and error text \"" . $verification['error_text'] . "\"\n";
+}
 ```
 
 ### Searching For A Verification


### PR DESCRIPTION
Adding better docs to answer a question that we got recently. Failing verification is an expected outcome, but we throw an exception which can confuse users. Documenting the current process to make this easier. Fixes #125 