### PR TITLE
Remove undefined variable

### DIFF
--- a/src/Account/Client.php
+++ b/src/Account/Client.php
@@ -92,7 +92,7 @@ class Client implements ClientAwareInterface
         $response = $this->client->send($request);
 
         if($response->getStatusCode() != '200'){
-            throw $this->getException($response, $application);
+            throw $this->getException($response);
         }
     }
 


### PR DESCRIPTION
The variable `$application` in `Account\Client::topUp()` is undefined, thus it shouldn't be used.