### PR TITLE
PHP 7.3 fix

### DIFF
--- a/src/Message/Client.php
+++ b/src/Message/Client.php
@@ -58,7 +58,7 @@ class Client implements ClientAwareInterface
         foreach($data['messages'] as $part){
             switch($part['status']){
                 case '0':
-                    continue; //all okay
+                    break; //all okay
                 case '1':
                     if(preg_match('#\[\s+(\d+)\s+\]#', $part['error-text'], $match)){
                         usleep($match[1] + 1);


### PR DESCRIPTION
Fix the error "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"