### PR TITLE
Use clearer placeholders in example. Fixes #157

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,10 @@ All `$client->calls()` methods require the client to be constructed with a `Nexm
 
 ```php
 $basic  = new \Nexmo\Client\Credentials\Basic('key', 'secret');
-$keypair = new \Nexmo\Client\Credentials\Keypair(file_get_contents(__DIR__ . '/application.key'), 'application_id');
+$keypair = new \Nexmo\Client\Credentials\Keypair(
+    file_get_contents((NEXMO_APPLICATION_PRIVATE_KEY_PATH),
+    NEXMO_APPLICATION_ID
+);
 
 $client = new \Nexmo\Client(new \Nexmo\Client\Credentials\Container($basic, $keypair));
 ```


### PR DESCRIPTION
We had a suggestion that the placeholder style we use in our building blocks would be easier to understand than hardcoded values for a specific example. I agreed, and here it is!