### PR TITLE
Improve error handling in Insights\Client

### DIFF
--- a/src/Insights/Client.php
+++ b/src/Insights/Client.php
@@ -101,12 +101,13 @@ class Client implements ClientAwareInterface
     protected function getException(ResponseInterface $response)
     {
         $body = json_decode($response->getBody()->getContents(), true);
+        $body_error = isset($body['error-code-label']) ? $body['error-code-label'] : 'Unknown error';
         $status = $response->getStatusCode();
 
         if($status >= 400 AND $status < 500) {
-            $e = new Exception\Request($body['error-code-label'], $status);
+            $e = new Exception\Request($body_error, $status);
         } elseif($status >= 500 AND $status < 600) {
-            $e = new Exception\Server($body['error-code-label'], $status);
+            $e = new Exception\Server($body_error, $status);
         } else {
             $e = new Exception\Exception('Unexpected HTTP Status Code');
             throw $e;

--- a/src/Insights/Client.php
+++ b/src/Insights/Client.php
@@ -11,6 +11,7 @@ namespace Nexmo\Insights;
 use Nexmo\Client\ClientAwareInterface;
 use Nexmo\Client\ClientAwareTrait;
 use Nexmo\Client\Exception;
+use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Request;
 
 /**
@@ -90,13 +91,11 @@ class Client implements ClientAwareInterface
 
         $response = $this->client->send($request);
 
-        $insightsResults = json_decode($response->getBody()->getContents(), true);
-
         if('200' != $response->getStatusCode()){
             throw $this->getException($response);
         }
 
-        return $insightsResults;
+        return json_decode($response->getBody()->getContents(), true);
     }
 
     protected function getException(ResponseInterface $response)

--- a/test/Insights/ClientTest.php
+++ b/test/Insights/ClientTest.php
@@ -8,6 +8,7 @@
 
 namespace NexmoTest\Insights;
 
+use Nexmo\Client\Exception;
 use Nexmo\Insights\AdvancedCnam;
 use Nexmo\Insights\Basic;
 use Nexmo\Insights\Standard;
@@ -79,6 +80,45 @@ class ClientTest extends TestCase
         $this->checkInsightsRequest('advanced', '/ni/advanced/json', Advanced::class);
     }
 
+    public function errorProvider()
+    {
+        // yield 'testcasename' => ['methodToCall', 'expectedPath', 'expectedException', 'expectedMsg', 'expectedStatus'];
+        yield 'basicRequest' => ['basic', '/ni/basic/json', Exception\Request::class, 'basic_request_error', 400];
+        yield 'basicServer' => ['basic', '/ni/basic/json', Exception\Server::class, 'basic_server_error', 500];
+        yield 'basicUnexpected' => ['basic', '/ni/basic/json', Exception\Exception::class, 'basic_unexpected_error', 399];
+        yield 'standardRequest' => ['standard', '/ni/standard/json', Exception\Request::class, 'standard_request_error', 400];
+        yield 'standardServer' => ['standard', '/ni/standard/json', Exception\Server::class, 'standard_server_error', 500];
+        yield 'standardUnexpected' => ['standard', '/ni/standard/json', Exception\Exception::class, 'standard_unexpected_error', 399];
+        yield 'advancedRequest' => ['advanced', '/ni/advanced/json', Exception\Request::class, 'advanced_request_error', 400];
+        yield 'advancedServer' => ['advanced', '/ni/advanced/json', Exception\Server::class, 'advanced_server_error', 500];
+        yield 'advancedUnexpected' => ['advanced', '/ni/advanced/json', Exception\Exception::class, 'advanced_unexpected_error', 399];
+    }
+
+    /**
+     * @dataProvider errorProvider
+     */
+    public function testInsightsRequestError($methodToCall, $expectedPath, $expectedException, $expectedMessage, $expectedStatus)
+    {
+        $this->nexmoClient->send(Argument::that(function (RequestInterface $request)  use ($expectedPath){
+            $this->assertEquals($expectedPath, $request->getUri()->getPath());
+            $this->assertEquals('api.nexmo.com', $request->getUri()->getHost());
+            $this->assertEquals('GET', $request->getMethod());
+
+            $this->assertRequestQueryContains("number", "14155550100", $request);
+            return true;
+        }))->willReturn($this->getErrorResponse($expectedMessage, $expectedStatus));
+
+        $this->expectException($expectedException);
+        if ($expectedStatus > 399 and $expectedStatus < 600) {
+            $this->expectExceptionMessage($expectedMessage);
+            $this->expectExceptionCode($expectedStatus);
+        } else {
+            $this->expectExceptionMessage('Unexpected HTTP Status Code');
+            $this->expectExceptionCode(0);
+        }
+        $insightsStandard = $this->insightsClient->$methodToCall('14155550100');
+    }
+
     protected function checkInsightsRequest($methodToCall, $expectedPath, $expectedClass)
     {
         $this->nexmoClient->send(Argument::that(function (RequestInterface $request)  use ($expectedPath){
@@ -121,5 +161,13 @@ class ClientTest extends TestCase
     protected function getResponse($type = 'success', $code = 200)
     {
         return new Response(fopen(__DIR__ . '/responses/' . $type . '.json', 'r'), $code);
+    }
+
+    protected function getErrorResponse($error_code = 'test error', $status = 400)
+    {
+        $datstream = fopen('data://text/plain,{"error-code-label":"'. $error_code . '"}', 'r');
+        $response = new Response($datstream, $status);
+
+        return $response;
     }
 }

--- a/test/Insights/ClientTest.php
+++ b/test/Insights/ClientTest.php
@@ -119,6 +119,23 @@ class ClientTest extends TestCase
         $insightsStandard = $this->insightsClient->$methodToCall('14155550100');
     }
 
+    public function testUnexpectedErrorBody()
+    {
+        $empty_json_payload = '{}';
+        $http_status = 400;
+        $expected_exception_type = Exception\Request::class;
+        $expected_exception_msg = 'Unknown error';
+        $this->nexmoClient->send(Argument::type(RequestInterface::class))
+            // return a Response w/ http status 400, but no error-code-label element
+            ->willReturn(new Response(fopen('data://text/plain,' . $empty_json_payload, 'r'), $http_status));
+
+        $this->expectException($expected_exception_type);
+        $this->expectExceptionMessage($expected_exception_msg);
+        $this->expectExceptionCode($http_status);
+
+        $this->insightsClient->basic('');
+    }
+
     protected function checkInsightsRequest($methodToCall, $expectedPath, $expectedClass)
     {
         $this->nexmoClient->send(Argument::that(function (RequestInterface $request)  use ($expectedPath){


### PR DESCRIPTION
This PR addresses one issue raised in #147:

> Additionally if the Nexmo API response is not 200, the code fails with this:
> `Argument 1 passed to Nexmo\Insights\Client::getException() must be an instance of Nexmo\Insights\ResponseInterface, instance of GuzzleHttp\Psr7\Response given, called in vendor\nexmo\client\src\Insights\Client.php on line 96`

The issue was a missing `use` statement.

I added a unit test to exercise the `getException` method and validate the fix.

I also moved the call to `$response->getBody()->getContents()` until _after_ the call to `getException`. Otherwise the attempt to `getContents` in `getException` wouldn't find anything as we'd be at the end of the stream.

Also did a check on the contents of the body before attempting to access `$body['error-code-label']`