### PR TITLE
Make Client Guzzle agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To use the client library you'll need to have [created a Nexmo account][signup].
 To install the PHP client library to your project, we recommend using [Composer](https://getcomposer.org/).
 
 ```bash
-composer require nexmo/client
+composer require nexmo/client php-http/guzzle6-adapter
 ```
 
 > You don't need to clone this repository to use this library in your own projects. Use Composer to install it from Packagist.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "php-http/client-implementation": "^1.0",
     "zendframework/zend-diactoros": "^2.1",
     "php-http/guzzle6-adapter": "^2.0",
-    "lcobucci/jwt": "^3.2"
+    "lcobucci/jwt": "^3.2",
+    "php-http/discovery": "^1.6"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "php": ">=5.6",
     "php-http/client-implementation": "^1.0",
     "zendframework/zend-diactoros": "^2.1",
-    "php-http/guzzle6-adapter": "^2.0",
     "lcobucci/jwt": "^3.2",
     "php-http/discovery": "^1.6"
   },
@@ -27,6 +26,9 @@
     "php-http/mock-client": "^1.3.0",
     "estahn/phpunit-json-assertions": "^1.0.0",
     "squizlabs/php_codesniffer": "^3.1"
+  },
+  "suggest": {
+    "php-http/guzzle6-adapter": "Guzzle 6 HTTP Adapter"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
   "require": {
     "php": ">=5.6",
     "php-http/client-implementation": "^1.0",
-    "zendframework/zend-diactoros": "^1.3",
-    "php-http/guzzle6-adapter": "^1.0",
+    "zendframework/zend-diactoros": "^2.1",
+    "php-http/guzzle6-adapter": "^2.0",
     "lcobucci/jwt": "^3.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",
-    "php-http/mock-client": "^0.3.0",
+    "php-http/mock-client": "^1.3.0",
     "estahn/phpunit-json-assertions": "^1.0.0",
     "squizlabs/php_codesniffer": "^3.1"
   },

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,7 +7,8 @@
  */
 
 namespace Nexmo;
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
+use Http\Discovery\Psr18ClientDiscovery;
 use Nexmo\Client\Credentials\Basic;
 use Nexmo\Client\Credentials\Container;
 use Nexmo\Client\Credentials\CredentialsInterface;
@@ -52,7 +53,7 @@ class Client
 
     /**
      * Http Client
-     * @var HttpClient
+     * @var ClientInterface
      */
     protected $client;
 
@@ -69,10 +70,10 @@ class Client
     /**
      * Create a new API client using the provided credentials.
      */
-    public function __construct(CredentialsInterface $credentials, $options = array(), HttpClient $client = null)
+    public function __construct(CredentialsInterface $credentials, $options = array(), ClientInterface $client = null)
     {
         if(is_null($client)){
-            $client = new \Http\Adapter\Guzzle6\Client();
+            $client = Psr18ClientDiscovery::find();
         }
 
         $this->setHttpClient($client);
@@ -135,10 +136,10 @@ class Client
      * This allows the default http client to be swapped out for a HTTPlug compatible
      * replacement.
      *
-     * @param HttpClient $client
+     * @param ClientInterface $client
      * @return $this
      */
-    public function setHttpClient(HttpClient $client)
+    public function setHttpClient(ClientInterface $client)
     {
         $this->client = $client;
         return $this;
@@ -147,7 +148,7 @@ class Client
     /**
      * Get the Http Client used to make API requests.
      *
-     * @return HttpClient
+     * @return ClientInterface
      */
     public function getHttpClient()
     {
@@ -262,7 +263,7 @@ class Client
         }
         throw new Exception(get_class($this->credentials).' does not support JWT generation');
     }
-    
+
     /**
      * Takes a URL and a key=>value array to generate a GET PSR-7 request object
      *


### PR DESCRIPTION
This PR replaces #163.

The point here is to decouple the Client from Guzzle to allow end users to use whatever http client implementation they want.  

Long story short, I needed to create an API for another tool relying on HTTPlug 2.0 but this library did not allow me to use it because it relies on guzzle-adapter 1.6.3. 

The build wont pass because nexmo/client build is configured to run on php 5.6 and 7.0. But Guzzle Adapters does not support PHP <7.1. Do you want me to remove support for those versions as well?