### PR TITLE
Bump ZF diactoros version after security alert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=5.6",
     "php-http/client-implementation": "^1.0",
-    "zendframework/zend-diactoros": "^1.8.4",
+    "zendframework/zend-diactoros": "^1.8.4 || ^2.0",
     "php-http/guzzle6-adapter": "^1.0",
     "lcobucci/jwt": "^3.2"
   },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=5.6",
     "php-http/client-implementation": "^1.0",
-    "zendframework/zend-diactoros": "^1.3",
+    "zendframework/zend-diactoros": "^1.8.4",
     "php-http/guzzle6-adapter": "^1.0",
     "lcobucci/jwt": "^3.2"
   },


### PR DESCRIPTION
It doesn't seem to require a significant bump in other requirements, and still supports PHP 5.6.

We've had this mentioned a few times: #167 saw it coming from the Laravel component, as did #171. It's mentioned in #151 (although there are other packages there). 