### PR TITLE
Return empty array a Numbers search returns no results

### DIFF
--- a/src/Numbers/Client.php
+++ b/src/Numbers/Client.php
@@ -171,7 +171,8 @@ class Client implements ClientAwareInterface
 
         $searchResults = json_decode($response->getBody()->getContents(), true);
         if(empty($searchResults)){
-            throw new Exception\Request('number not found', 404);
+            // we did not find any results, that's OK
+            return [];
         }
 
         if(!isset($searchResults['count']) OR !isset($searchResults['numbers'])){


### PR DESCRIPTION
Fixes #178. This is a breaking change as previously this would have thrown an exception.