### PR TITLE
Remove beta indications, we're definitely not in Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,3 +695,13 @@ Contributing
 
 This library is actively developed and we love to hear from you! Please feel free to [create an issue][issues] or [open a pull request][pulls] with your questions, comments, suggestions and feedback.
 
+[signup]: https://dashboard.nexmo.com/sign-up?utm_source=DEV_REL&utm_medium=github&utm_campaign=php-client-library
+[doc_sms]: https://developer.nexmo.com/messaging/sms/overview
+[doc_inbound]: https://developer.nexmo.com/messaging/sms/guides/inbound-sms
+[doc_verify]: https://developer.nexmo.com/verify/overview
+[license]: LICENSE.txt
+[send_example]: examples/send.php
+[spec]: https://github.com/Nexmo/client-library-specification
+[issues]: https://github.com/Nexmo/nexmo-php/issues
+[pulls]: https://github.com/Nexmo/nexmo-php/pulls
+

--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@ Client Library for PHP
 *This library requires a minimum PHP version of 5.6*
 
 This is the PHP client library for use Nexmo's API. To use this, you'll need a Nexmo account. Sign up [for free at 
-nexmo.com][signup]. This is currently a beta release, see [contributing](#contributing) for more information.
+nexmo.com][signup].
 
  * [Installation](#installation)
  * [Usage](#usage)
  * [Examples](#examples)
- * [Coverage](#api-coverage)
  * [Contributing](#contributing) 
 
 Installation
@@ -690,61 +689,11 @@ $adapter_client = new Http\Adapter\Guzzle6\Client(new GuzzleHttp\Client(['timeou
 $nexmo_client = new Nexmo\Client(new Nexmo\Client\Credentials\Basic($api_key, $api_secret), [], $adapter_client);
 ```
 
-API Coverage
-------------
-
-* Account
-    * [X] Balance
-    * [X] Pricing
-    * [ ] Settings
-    * [X] Top Up
-    * [X] Secret Management
-    * [X] Pricing
-    * [X] Numbers
-        * [X] Search
-        * [X] Buy
-        * [X] Cancel
-        * [X] Update
-* Number Insight
-    * [X] Basic
-    * [X] Standard
-    * [X] Advanced
-    * [X] Webhook Notification
-* Verify
-    * [X] Verify
-    * [X] Check
-    * [X] Search
-    * [X] Control
-* Messaging 
-    * [X] Send
-    * [X] Delivery Receipt
-    * [X] Inbound Messages
-    * [X] Search
-        * [X] Message
-        * [X] Messages
-        * [X] Rejections
-    * [X] US Short Codes
-        * [X] Two-Factor Authentication
-        * [X] Event Based Alerts
-            * [X] Sending Alerts
-            * [X] Campaign Subscription Management
-* Voice
-    * [X] Outbound Call
-    * [X] Outbound Call with an NCCO
-    * [X] Inbound Call
-    * [X] Text-To-Speech Call
-    * [X] Text-To-Speech Prompt
 
 Contributing
 ------------
 
-This library is currently being refactored from an earlier prototype to match the current [client library spec][spec].
-The `legacy` branch can be used to require that earlier version. During the transition the `develop` and `master` 
-branches will have both new and legacy code. The [API coverage](#API-Coverage) section identifies what features are 
-currently implemented and up to date. 
-
-To contribute to the library, docs, or examples, [create an issue][issues] or [a pull request][pulls]. Please only raise issues
-about features marked as working in the [API coverage](#API-Coverage) as the rest of the code is being updated.
+This library is actively developed and we love to hear from you! Please feel free to [create an issue][issues] or [open a pull request][pulls] with your questions, comments, suggestions and feedback.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -695,18 +695,3 @@ Contributing
 
 This library is actively developed and we love to hear from you! Please feel free to [create an issue][issues] or [open a pull request][pulls] with your questions, comments, suggestions and feedback.
 
-License
--------
-
-This library is released under the [MIT License][license]
-
-[signup]: https://dashboard.nexmo.com/sign-up?utm_source=DEV_REL&utm_medium=github&utm_campaign=php-client-library
-[doc_sms]: https://developer.nexmo.com/messaging/sms/overview
-[doc_inbound]: https://developer.nexmo.com/messaging/sms/guides/inbound-sms
-[doc_verify]: https://developer.nexmo.com/verify/overview
-[license]: LICENSE.txt
-[send_example]: examples/send.php
-[spec]: https://github.com/Nexmo/client-library-specification
-[issues]: https://github.com/Nexmo/nexmo-php/issues
-[pulls]: https://github.com/Nexmo/nexmo-php/pulls
-


### PR DESCRIPTION
I noticed (on packagist, where the formatting is different) that the library says we're still in beta. We're definitely stable now so I updated that, and I tidied up a few other things while I was here:

* Remove license section, we have the badge and also indicate our license in the standard GitHub way with a LICENSE file which I think users expect now
* Remove API coverage section, we've got all the coverage now