### PR TITLE
Add workflow_id support for Verify API

### DIFF
--- a/src/Verify/Verification.php
+++ b/src/Verify/Verification.php
@@ -267,6 +267,21 @@ class Verification implements VerificationInterface, \ArrayAccess, \Serializable
     }
 
     /**
+     * Which workflow to use, default is 1 for SMS -> TTS -> TTS
+     * @link https://developer.nexmo.com/verify/guides/workflows-and-events
+     *
+     * Can only be set before the verification is created.
+     * @uses \Nexmo\Entity\RequestArrayTrait::setRequestData
+     *
+     * @param int $workflow_id Which workflow to use
+     * @return $this
+     */
+    public function setWorkflowId($workflow_id)
+    {
+        return $this->setRequestData('workflow_id', $workflow_id);
+    }
+
+    /**
      * Get the verification request id, if available.
      *
      * @uses \Nexmo\Verify\Verification::proxyArrayAccess()

--- a/src/Verify/VerificationInterface.php
+++ b/src/Verify/VerificationInterface.php
@@ -18,4 +18,5 @@ interface VerificationInterface extends \Nexmo\Entity\EntityInterface
     public function setRequireType($type);
     public function setPinExpiry($time);
     public function setWaitTime($time);
+    public function setWorkflowId($workflow_id);
 }


### PR DESCRIPTION
To use all the optional parameters, you have to instantiate a verification and then call the `setThing()` methods on it before you call `start()`. I've followed this pattern for consistency.