### PR TITLE
Calls Collection/Client now handles being called by MapFactory

### DIFF
--- a/src/Call/Collection.php
+++ b/src/Call/Collection.php
@@ -59,9 +59,10 @@ class Collection implements ClientAwareInterface, CollectionInterface, \ArrayAcc
      * @param null $callOrFilter
      * @return $this|Call
      */
-    public function __invoke(Filter $filter = null)
+    public function __invoke($filter = null)
     {
-        if (!is_null($filter)) {
+        /** Fix for the smarter MapFactory in v2.2.0 and the uniqueness of this class interface */
+        if (!is_null($filter) && $filter instanceof Filter) {
             $this->setFilter($filter);
         }
 


### PR DESCRIPTION
`MapFactory` now supports factories via the `__invoke()` method on a class, and `Nexmo\Calls\Collection` is of course an invokable object. That didn't play well.

This removes the typehint on `Nexmo\Calls\Collection::__invoke()`, which is fine since this class is deprecated anyway.