### PR TITLE
Added Country to searchOwned

### DIFF
--- a/src/Numbers/Client.php
+++ b/src/Numbers/Client.php
@@ -239,6 +239,7 @@ class Client implements ClientAwareInterface, APIClient
 
         // These are all optional parameters
         $possibleParameters = [
+            'country' => 'string',
             'pattern' => 'string',
             'search_pattern' => 'integer',
             'size' => 'integer',

--- a/test/Numbers/ClientTest.php
+++ b/test/Numbers/ClientTest.php
@@ -291,6 +291,7 @@ class ClientTest extends TestCase
             'size' => '100',
             'search_pattern' => 0,
             'has_application' => false,
+            'country' => 'GB',
         ]);
     }
 


### PR DESCRIPTION
The documentation for this function points to there being a country argument (https://developer.nexmo.com/api/numbers#getOwnedNumbers), but the function doesn't allow this.

Adding the string here allows this to be passed through.